### PR TITLE
Us 27 admin merchant enabledisable

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -14,17 +14,30 @@ class Admin::MerchantsController < ApplicationController
 
   def update
     @merchant = Merchant.find(params[:id])
-  
-    if @merchant.update(merchant_params)
-      flash[:notice] = "Merchant information updated successfully"
-      redirect_to admin_merchant_path(@merchant)
+
+    if params[:merchant]
+      if @merchant.update(merchant_params)
+        flash[:notice] = "Merchant information updated successfully"
+        redirect_to admin_merchant_path(@merchant)
+      else
+        render 'edit'
+      end
     else
-      render 'edit'
+      toggle_merch_status
+      redirect_to admin_merchants_path
     end
   end
 
   private 
   def merchant_params
     params.require(:merchant).permit(:name)
+  end
+
+  def toggle_merch_status
+    if @merchant.enabled?
+      @merchant.disabled!
+    elsif @merchant.disabled?
+      @merchant.enabled!
+    end
   end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -23,4 +23,12 @@ class Merchant < ApplicationRecord
   def unique_invoices
     invoices.distinct
   end
+
+  def opposite_status
+    if self.enabled?
+      'Disable'
+    else
+      'Enable'
+    end
+  end
 end

--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -4,6 +4,7 @@ class Merchant < ApplicationRecord
   has_many :invoices, through: :invoice_items
   has_many :customers, through: :invoices
   has_many :transactions, through: :invoices
+  enum status: { disabled: 0, enabled: 1 }
 
   def favorite_customers
     customers.joins(transactions: [invoice: { invoice_items: :item }])

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,6 +10,9 @@
 
 <div>
   <% @merchants.each do |merchant|%>
-    <p><%=  link_to "#{merchant.name}", admin_merchant_path(merchant) %></p>
+    <div id="merchant-<%= merchant.id %>">
+      <p><%=  link_to "#{merchant.name}", admin_merchant_path(merchant) %></p>
+      <p><%=  button_to "#{merchant.opposite_status}", admin_merchant_path(merchant), method: :patch %></p>
+    </div>
   <% end %>
 </div>

--- a/db/migrate/20230417185907_add_status_to_merchant.rb
+++ b/db/migrate/20230417185907_add_status_to_merchant.rb
@@ -1,0 +1,5 @@
+class AddStatusToMerchant < ActiveRecord::Migration[5.2]
+  def change
+    add_column :merchants, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_04_11_201634) do
+ActiveRecord::Schema.define(version: 2023_04_17_185907) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2023_04_11_201634) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0
   end
 
   create_table "transactions", force: :cascade do |t|

--- a/spec/factories/merchants.rb
+++ b/spec/factories/merchants.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :merchant do
     sequence(:id)
     name { Faker::Company.name }
+    status { Faker::Number.between(from: 0, to: 1) }
     created_at { Time.zone.now }
     updated_at { Time.zone.now }
   end

--- a/spec/features/admin/merchants/edit_spec.rb
+++ b/spec/features/admin/merchants/edit_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe '/admin/merchants/:id/edit', type: :feature do
+  before(:each) do
+    @merch_1 = create(:merchant)
+    @merch_2 = create(:merchant)
+
+    visit "/admin/merchants/#{@merch_1.id}/edit"
+  end
+
+  describe 'Admin merchant edit page' do
+    it 'displays Edit form' do
+      expect(page).to have_field('merchant_name', with: "#{@merch_1.name}")
+      fill_in('merchant_name', with: 'Boston')
+      click_button 'Update Merchant'
+      expect(current_path).to eq(admin_merchant_path(@merch_1.id))
+      expect(page).to have_content("Boston")
+    end
+  end
+end

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -3,23 +3,69 @@ require 'rails_helper'
 RSpec.describe '/admin/merchants', type: :feature do
   before(:each) do
     delete_data
-    @merch_1 = create(:merchant)
-    @merch_2 = create(:merchant)
-    @merch_3 = create(:merchant)
+    @merch_1 = create(:merchant, status: 0) # enable
+    @merch_2 = create(:merchant, status: 1) # disable
+    @merch_3 = create(:merchant, status: 1) # disable
 
     visit '/admin/merchants'
   end
 
   describe 'When I visit the admin merchants index ' do
-    it 'I see the name of each merchant in the system' do
-      expect(page).to have_content(@merch_1.name)
-      expect(page).to have_content(@merch_2.name)
-      expect(page).to have_content(@merch_3.name)
+    describe 'User Story 24' do
+      it 'I see the name of each merchant in the system' do
+        expect(page).to have_content(@merch_1.name)
+        expect(page).to have_content(@merch_2.name)
+        expect(page).to have_content(@merch_3.name)
+      end
     end
 
-    it 'I click on the name of a merchant then I am taken to that merchants admin show page ' do
-      click_link "#{@merch_1.name}"
-      expect(current_path).to eq(admin_merchant_path(@merch_1))
+    describe 'User Story 25' do
+      it 'I click on the name of a merchant then I am taken to that merchants admin show page ' do
+        click_link "#{@merch_1.name}"
+        expect(current_path).to eq(admin_merchant_path(@merch_1))
+      end
+    end
+
+    describe 'User Story 27' do
+      it 'Then I see a button to disable/enable for each merchant' do
+        within("#merchant-#{@merch_1.id}") do
+          expect(page).to have_button('Enable')
+        end
+
+        within("#merchant-#{@merch_2.id}") do
+          expect(page).to have_button('Disable')
+        end
+
+        within("#merchant-#{@merch_3.id}") do
+          expect(page).to have_button('Disable')
+        end
+      end
+
+      it 'When I clicked enable I am redirected to the admin merchants index and status is changed to disabled' do
+        within("#merchant-#{@merch_1.id}") do
+          expect(page).to have_button('Enable')
+          click_button('Enable')
+        end
+
+        expect(current_path).to eq('/admin/merchants')
+
+        within("#merchant-#{@merch_1.id}") do
+          expect(page).to have_button('Disable')
+        end
+      end
+
+      it 'When I clicked disable I am redirected to the admin merchants index and status is changed to enabled' do
+        within("#merchant-#{@merch_2.id}") do
+          expect(page).to have_button('Disable')
+          click_button('Disable')
+        end
+
+        expect(current_path).to eq('/admin/merchants')
+        # save_and_open_page
+        within("#merchant-#{@merch_2.id}") do
+          expect(page).to have_button('Enable')
+        end
+      end
     end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -12,6 +12,13 @@ RSpec.describe Merchant do
     it { should have_many(:transactions).through(:invoices) }
   end
 
+  describe 'enum' do
+    it 'defines status as enum' do
+      should define_enum_for(:status).
+        with_values(disabled: 0, enabled: 1)
+    end
+  end
+
   describe '#instance methods' do
     describe '#favorite_customers' do
       before(:each) do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -44,5 +44,15 @@ RSpec.describe Merchant do
         expect(@merch_2.unique_invoices.sort).to eq([@invoice_2, @invoice_3])
       end
     end
+
+    describe '#opposite_status' do 
+      it 'returns the opposite status' do
+        merchant1 = create(:merchant, status: 0)
+        merchant2 = create(:merchant, status: 1)
+
+        expect(merchant1.opposite_status).to eq('Enable')
+        expect(merchant2.opposite_status).to eq('Disable')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Describe Changes
- Add status to Merchant with default 0 (disabled)
- Add enum for Merchant status and test
- Add status to Merchant factory
- Create feature test for Admin Merchant edit page
- Add feature for Admin Merchant index to show enable/disable buttons and test
- Add Merchant #opposite_status and test

## Type of change

- [x] Complete a User Story (tests all passing)
- [x] Refactor 
- [ ] Bug fix 
- [x] Other: add status attribute to Merchant and add test for admin merchant edit page

## Extra! Extra! Read all about it!
- don't hate us for the admin merchant controller update action!! we tried our best! lol

## Number of Reviews
- [x] one
- [ ] two
- [ ] EVERYONE PLS!
