### PR TITLE
Us 28 admin merchants grouped by status

### DIFF
--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,8 +1,7 @@
 class Admin::MerchantsController < ApplicationController
 
   def index
-    @enabled_merchants = Merchant.where(status: 1)
-    @disabled_merchants = Merchant.where(status: 0)
+    @merchants = Merchant.all
   end
 
   def show

--- a/app/controllers/admin/merchants_controller.rb
+++ b/app/controllers/admin/merchants_controller.rb
@@ -1,7 +1,8 @@
 class Admin::MerchantsController < ApplicationController
 
   def index
-    @merchants = Merchant.all
+    @enabled_merchants = Merchant.where(status: 1)
+    @disabled_merchants = Merchant.where(status: 0)
   end
 
   def show

--- a/app/views/admin/merchants/_merchant_list.html.erb
+++ b/app/views/admin/merchants/_merchant_list.html.erb
@@ -1,0 +1,6 @@
+<% merchants.each do |merchant|%>
+    <div id="merchant-<%= merchant.id %>">
+      <p><%=  link_to "#{merchant.name}", admin_merchant_path(merchant) %></p>
+      <p><%=  button_to "#{merchant.opposite_status}", admin_merchant_path(merchant), method: :patch %></p>
+    </div>
+<% end %>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -10,10 +10,10 @@
 
 <div id="enabled-merchants">
 <h3>Enabled Merchants</h3>
-<%= render partial: "merchant_list", locals: { merchants: @enabled_merchants } %>
+<%= render partial: "merchant_list", locals: { merchants: @merchants.enabled } %>
 </div>
 
 <div id="disabled-merchants">
 <h3>Disabled Merchants</h3>
-  <%= render partial: "merchant_list", locals: { merchants: @disabled_merchants } %>
+  <%= render partial: "merchant_list", locals: { merchants: @merchants.disabled } %>
 </div>

--- a/app/views/admin/merchants/index.html.erb
+++ b/app/views/admin/merchants/index.html.erb
@@ -8,11 +8,12 @@
   <%= link_to 'Invoices', '/admin/invoices', method: :get %>
 </div>
 
-<div>
-  <% @merchants.each do |merchant|%>
-    <div id="merchant-<%= merchant.id %>">
-      <p><%=  link_to "#{merchant.name}", admin_merchant_path(merchant) %></p>
-      <p><%=  button_to "#{merchant.opposite_status}", admin_merchant_path(merchant), method: :patch %></p>
-    </div>
-  <% end %>
+<div id="enabled-merchants">
+<h3>Enabled Merchants</h3>
+<%= render partial: "merchant_list", locals: { merchants: @enabled_merchants } %>
+</div>
+
+<div id="disabled-merchants">
+<h3>Disabled Merchants</h3>
+  <%= render partial: "merchant_list", locals: { merchants: @disabled_merchants } %>
 </div>

--- a/spec/features/admin/merchants/index_spec.rb
+++ b/spec/features/admin/merchants/index_spec.rb
@@ -67,6 +67,24 @@ RSpec.describe '/admin/merchants', type: :feature do
         end
       end
     end
+
+    describe 'User Story 28' do
+      it 'I see two sections for each of "Enabled/Disabled Merchants" and merchants listed accordingly' do
+        within("#enabled-merchants") do
+          expect(page).to have_content("Enabled Merchants")
+          expect(page).to_not have_content(@merch_1.name)
+          expect(page).to have_content(@merch_2.name)
+          expect(page).to have_content(@merch_3.name)
+        end
+
+        within("#disabled-merchants") do
+          expect(page).to have_content("Disabled Merchants")
+          expect(page).to have_content(@merch_1.name)
+          expect(page).to_not have_content(@merch_2.name)
+          expect(page).to_not have_content(@merch_3.name)
+        end
+      end
+    end
   end
 end
 


### PR DESCRIPTION
## Describe Changes
- Add feature test to Admin Merchants index page to show enabled and disabled merchants sections
- Add partial to list merchants
- Refactored Admin Merchants index page to show enabled and disabled merchants sections and list with partial

## Type of change

- [x] Complete a User Story (tests all passing)
- [ ] Refactor 
- [ ] Bug fix 
- [ ] Other: (describe here!)

## Extra! Extra! Read all about it!
- paired with Boston!
- FYI - we changed the controller, but discarded them because we found a better way! (hence refactor in commit no. 5384682)

## Number of Reviews
- [x] one
- [ ] two
- [ ] EVERYONE PLS!
