### PR TITLE
13 us 17 merchant invoice show page total revenue

### DIFF
--- a/app/models/merchant.rb
+++ b/app/models/merchant.rb
@@ -37,5 +37,13 @@ class Merchant < ApplicationRecord
       'Enable'
     end
   end
+
+  def total_revenue(invoice)
+    revenue = 0
+    items_on_invoice(invoice).each do |item|
+      revenue += (item.unit_price * item.quantity)
+    end
+    revenue
+  end
 end
 

--- a/app/views/merchants/invoices/show.html.erb
+++ b/app/views/merchants/invoices/show.html.erb
@@ -20,6 +20,9 @@
   Status: <%= @invoice.status %><br>
   <br>
   Created on: <%= @invoice.created_day_mdy %><br>
+  <br>
+  <% revenue = @merchant.total_revenue(@invoice)%>
+  Total Revenue: <%= number_to_currency(revenue.to_f / 100) %>
 </div>
 <br>
 <div id="customer-info">

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -88,5 +88,11 @@ RSpec.describe 'merchants invoice show page' do
         expect(page).to have_content(@invoice_item_2.status)
       end
     end
+    it "shows me  the total revenue from all of my items on the invoice" do
+      visit "/merchants/#{@merch_1.id}/invoices/#{@invoice_1.id}"
+      within("#invoice-info") do
+        expect(page).to have_content("Total Revenue: $39.47")
+      end
+    end
   end
 end

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -63,5 +63,13 @@ RSpec.describe Merchant do
         expect(merchant2.opposite_status).to eq('Disable')
       end
     end
+
+    describe "#total_revenue" do
+      it 'returns the revenue for a given invoice' do
+        us_16_test_data
+        expect(@merch_1.total_revenue(@invoice_1)).to eq(3947)
+        expect(@merch_2.total_revenue(@invoice_1)).to eq(5899)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Describe Changes
- Merchant Invoice show page will display the total revenue for that merchant on that invoice
- Added tests for US as well

## Type of change

- [x] Complete a User Story (tests all passing)
- [ ] Refactor 
- [ ] Bug fix 
- [ ] Other: (describe here!)

## Extra! Extra! Read all about it!
- Please see slack for a couple of questions

## Number of Reviews
- [ ] one
- [x] two
- [ ] EVERYONE PLS!
